### PR TITLE
changes for adding ring shortcuts

### DIFF
--- a/examples/example_gui_execution.py
+++ b/examples/example_gui_execution.py
@@ -17,7 +17,6 @@ if __name__ == "__main__":
     # load
     from restraintmaker import test
     in_file_path = test.test_system1_pdb
-    in_file_path = test.test_system3_pdb
     cmd.load(in_file_path)
 
     # visualization

--- a/examples/example_gui_execution.py
+++ b/examples/example_gui_execution.py
@@ -17,6 +17,7 @@ if __name__ == "__main__":
     # load
     from restraintmaker import test
     in_file_path = test.test_system1_pdb
+    in_file_path = test.test_system3_pdb
     cmd.load(in_file_path)
 
     # visualization

--- a/restraintmaker/algorithm/Optimizer.py
+++ b/restraintmaker/algorithm/Optimizer.py
@@ -197,7 +197,7 @@ class _MoleculeRingOptimizer(_Optimizer):
             print("_" * 20 + "\n", mv=_verbosity_level)
             print("Translate back to distance restraints with atom idx", mv=_verbosity_level)
             print("_" * 20 + "\n", mv=_verbosity_level)
-            print("Number of restraint pairs: "+str(len(restraints_list)), mv=_verbosity_level)
+            print("Number of selected restraint pairs: "+str(len(i_chosen_pairs))+" / "+str(len(restraints_list)), mv=_verbosity_level)
             chosen_restraints = []
             for i in i_chosen_pairs:
                 #print(i, mv=5)
@@ -1157,7 +1157,7 @@ def maximal_weight_ring(edge_list: t.List[t.Tuple[int, int]], value_list: t.List
     # TODO: Clean: Start a new for loop, which starts where the one above ended. Do not check in loop if ind is bigger than possible, but just check with a for else statement that an edge was found
     # ADD the last edge: Does close ring, but is not allowed to fork
     found_last_edge = False
-    print('----------', mv=1)
+    print('---------- Close Ring', mv=_verbosity_level)
     for ind in sorted_by_value[last_position + 1:]:
         i_m1 = edge_list[ind][0]
         i_m2 = edge_list[ind][1]
@@ -1306,12 +1306,13 @@ def additional_ring_interconnections(molecule_pair_list:t.List[t.Tuple[int, int]
     print(molecule_pair_list, mv=_verbosity_level)
     print("Already Chosen Pairs: \t", mv=_verbosity_level)
     print(i_chosen_pairs, mv=_verbosity_level)
+    print("", mv=_verbosity_level)
 
-    # a) BUild Ring:
+    # a) Construct Molecule Ring for selection:
     mol_ring = []
     tmp_pair = None
     i=0
-    while(len(mol_ring)< len(i_chosen_pairs)):
+    while(len(mol_ring)< len(i_chosen_pairs)):  #sort tuples, such they form a ring.
         #print(i, mv=_verbosity_level)
         tp = molecule_pair_list[i_chosen_pairs[i]]
         if(tmp_pair is None):
@@ -1339,7 +1340,7 @@ def additional_ring_interconnections(molecule_pair_list:t.List[t.Tuple[int, int]
                 mol_chain.append(i[1])
             else:
                 mol_chain.append(i[0])
-    print("Molecule Chain:", mv=_verbosity_level)
+    print("Molecule Ring Chain:", mv=_verbosity_level)
     print(mol_chain, mv=_verbosity_level)
     print("", mv=_verbosity_level)
 
@@ -1376,9 +1377,9 @@ def additional_ring_interconnections(molecule_pair_list:t.List[t.Tuple[int, int]
 
     additional_restraint_pairs = additional_restraint_pairs
 
-    print("Dividers", mv=_verbosity_level)
+    print("Dividers:", mv=_verbosity_level)
     print(dividers, mv=_verbosity_level)
-    print("additional_restraint_pairs - molecule index in ring", mv=_verbosity_level)
+    print("additional_restraint_pairs - molecule index in ring:", mv=_verbosity_level)
     print(additional_restraint_pairs, mv=_verbosity_level)
 
     # c) Translation of additional restraints to mol tuples:
@@ -1396,7 +1397,8 @@ def additional_ring_interconnections(molecule_pair_list:t.List[t.Tuple[int, int]
     print("", mv=_verbosity_level)
 
     print("Results", mv=_verbosity_level)
-    print(i_chosen_pairs, mv=_verbosity_level)
+    print(str(len(i_chosen_pairs))+" - chosen restraintPairs: \n"+str(i_chosen_pairs), mv=_verbosity_level)
+    print("Molecule Pairs:", mv=_verbosity_level)
     print([molecule_pair_list[o] for o in i_chosen_pairs] , mv=_verbosity_level)
     print("", mv=_verbosity_level)
 

--- a/restraintmaker/algorithm/Optimizer.py
+++ b/restraintmaker/algorithm/Optimizer.py
@@ -1304,7 +1304,7 @@ def additional_ring_interconnections(molecule_pair_list:t.List[t.Tuple[int, int]
 
     print("Molecule Pairs: \t"+str(len(molecule_pair_list)), mv=_verbosity_level)
     print(molecule_pair_list, mv=_verbosity_level)
-    print("Already Chosen Pairs: \t", mv=_verbosity_level)
+    print("Already Chosen Pairs:\t"+str(len(i_chosen_pairs)), mv=_verbosity_level)
     print(i_chosen_pairs, mv=_verbosity_level)
     print("", mv=_verbosity_level)
 

--- a/restraintmaker/algorithm/Optimizer.py
+++ b/restraintmaker/algorithm/Optimizer.py
@@ -1361,10 +1361,10 @@ def additional_ring_interconnections(molecule_pair_list:t.List[t.Tuple[int, int]
             else:
                 if(tdiv == 0.5):
                     i = int(0)
-                    j = int(np.round(tdiv*nLigs))
+                    j = int(np.round(tdiv*nLigs))+1
                 else:
-                    i = int(np.round(tdiv*nLigs))
-                    j = int(np.round((0.5+tdiv)*nLigs))
+                    i = int(np.round(tdiv*nLigs))+1
+                    j = int(np.round((0.5+tdiv)*nLigs))+1
 
                 #print("nP\t"+str(nLigs), mv=_verbosity_level)
                 #print("div\t"+str(tdiv), mv=_verbosity_level)
@@ -1387,8 +1387,9 @@ def additional_ring_interconnections(molecule_pair_list:t.List[t.Tuple[int, int]
     print("Translation\n", mv=_verbosity_level)
 
     for add_tuple_ind in additional_restraint_pairs:
+        print(add_tuple_ind)
         print("tMolChainINd\t"+str(add_tuple_ind), mv=_verbosity_level)
-        molecule_indices = [mol_chain[i] for i in add_tuple_ind]
+        molecule_indices = [mol_chain[i%len(mol_chain)] for i in add_tuple_ind]
         print("tMolINds\t"+str(molecule_indices), mv=_verbosity_level)
         tups = [molecule_pair_list.index(tup) for tup in molecule_pair_list if(all([v in tup for v in molecule_indices]))]
         print("tupleIndex"+str(tups), mv=_verbosity_level)

--- a/restraintmaker/interface_Pymol/RestraintMaker_Logic.py
+++ b/restraintmaker/interface_Pymol/RestraintMaker_Logic.py
@@ -533,8 +533,8 @@ class Logic_Handler:
             input_function = qt_dialogs.create_multi_dialog(
                 title='Parameters for BruteForceOptimizer', \
                 inputs=['number of restraints', 'maximal distance of restraints',
-                        'algorithm', 'optimize molecules pairs by'], \
-                options={'algorithm': ['convex_hull', 'pca', 'addtional ring connections'],
+                        'algorithm', 'optimize molecules pairs by', 'addtional ring connections'], \
+                options={'algorithm': ['convex_hull', 'pca'],
                          'optimize molecules pairs by': ['None', 'convex_hull',
                                                          'pca_2d']}, \
                 default={'number of restraints': '4',

--- a/restraintmaker/interface_Pymol/RestraintMaker_Logic.py
+++ b/restraintmaker/interface_Pymol/RestraintMaker_Logic.py
@@ -518,14 +518,15 @@ class Logic_Handler:
             input_function = qt_dialogs.create_multi_dialog(
                 title='Parameters for GreedyGraphOptimizer', \
                 inputs=['number of restraints', 'maximal distance of restraints',
-                        'tree-algorithm', 'optimize molecules pairs by'], \
+                        'tree-algorithm', 'optimize molecules pairs by', 'addtional ring connections'], \
                 options={'tree-algorithm': ['minmax', 'cog', 'prim', "biased_avg"],
                          'optimize molecules pairs by': ['None', 'convex_hull',
                                                          'pca_2d']}, \
                 default={'number of restraints': '4',
                          'maximal distance of restraints': '1.0',
                          'algorithm': 'minmax',
-                         'optimize molecules pairs by': 'convex_hull'})
+                         'optimize molecules pairs by': 'convex_hull',
+                         'addtional ring connections': '0'})
 
 
         elif isinstance(self.my_optimizer, Optimizer.BruteForceRingOptimzer):
@@ -533,24 +534,29 @@ class Logic_Handler:
                 title='Parameters for BruteForceOptimizer', \
                 inputs=['number of restraints', 'maximal distance of restraints',
                         'algorithm', 'optimize molecules pairs by'], \
-                options={'algorithm': ['convex_hull', 'pca'],
+                options={'algorithm': ['convex_hull', 'pca', 'addtional ring connections'],
                          'optimize molecules pairs by': ['None', 'convex_hull',
                                                          'pca_2d']}, \
                 default={'number of restraints': '4',
-                         'maximal distance of restraints': '1.2', 'algorithm': 'pca',
-                         'optimize molecules pairs by': 'pca_2d'})
+                         'maximal distance of restraints': '1.2',
+                         'algorithm': 'pca',
+                         'optimize molecules pairs by': 'convex_hull',
+                         'addtional ring connections': '0'
+                         })
 
         elif isinstance(self.my_optimizer, Optimizer.MetaMoleculeRingOptimizer):
             input_function = qt_dialogs.create_multi_dialog(
                 title='Parameters for BestMoleculeRingOptimizer', \
                 inputs=['number of restraints', 'maximal distance of restraints',
-                        'algorithm', 'optimize molecules pairs by'], \
+                        'algorithm', 'optimize molecules pairs by', 'addtional ring connections'], \
                 options={'algorithm': ['convex_hull', 'pca'],
                          'optimize molecules pairs by': ['convex_hull',
                                                          'pca_2d']}, \
                 default={'number of restraints': '4',
                          'maximal distance of restraints': '1.2', 'algorithm': 'pca',
-                         'optimize molecules pairs by': 'pca_2d'})
+                         'optimize molecules pairs by': 'convex_hull',
+                         'addtional ring connections': '0'
+                         })
 
         if try_to_get_args(self.my_optimizer, input_function):
             time_start = time.time()

--- a/restraintmaker/test/__init__.py
+++ b/restraintmaker/test/__init__.py
@@ -9,3 +9,6 @@ test_system1_pdb = systems_file_folder+"/systemA/CHK1_5Ligs.pdb"
 
 #Test System2
 test_system2_pdb = systems_file_folder+"/systemB/BRD4_7Ligs.pdb"
+
+#Test System3
+test_system3_pdb = systems_file_folder+"/systemD/FXR_21ligs.pdb"


### PR DESCRIPTION
## Description
This PR adds the additional ring shortcuts as used by S. Rieder et al. 2022 in an automatic manner to the restraintmaker. These Additional ring shortcuts add additional restraints to the system, that can be used to avoid spacial end-state diffusion for very large amounts of end-states. If the end-states diffuse significantly away from each other a performance loss was observed, it can be counteracted by the additional restraints. 

The amount of ring-shortcuts is a user input currently. For the future it would be desirable to find a rule, that leads to a defined number of additional restraints depending on the Molecule - ring size and the force constant.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Test :) 

## Status
- [x] Ready to go